### PR TITLE
Use pypi version of toshiba-ac

### DIFF
--- a/custom_components/toshiba_ac/manifest.json
+++ b/custom_components/toshiba_ac/manifest.json
@@ -5,13 +5,13 @@
   "documentation": "https://github.com/h4de5/home-assistant-toshiba_ac",
   "issue_tracker": "https://github.com/h4de5/home-assistant-toshiba_ac/issues",
   "requirements": [
-    "toshiba_ac @ git+https://github.com/KaSroka/Toshiba-AC-control.git#egg=toshiba_ac"
+    "toshiba-ac==0.1.0"
   ],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},
   "dependencies": [],
   "codeowners": ["@h4de5"],
-  "version": "2021.8.3",
+  "version": "2021.8.4",
   "iot_class": "cloud_push"
 }


### PR DESCRIPTION
I have released toshiba-ac on pypi so we can use it with proper version.