### PR TITLE
Update toshiba-ac to 0.1.4

### DIFF
--- a/custom_components/toshiba_ac/__init__.py
+++ b/custom_components/toshiba_ac/__init__.py
@@ -6,8 +6,6 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 
-# from .toshiba_ac_control import toshiba_ac
-# from .toshiba_ac_control.toshiba_ac.device_manager import ToshibaAcDeviceManager
 from toshiba_ac.device_manager import ToshibaAcDeviceManager
 
 PLATFORMS = ["climate"]
@@ -25,19 +23,18 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Toshiba AC from a config entry."""
-    # TODO Store an API object for your platforms to access
-    # hass.data[DOMAIN][entry.entry_id] = MyApi(...)
 
-    device_manager = ToshibaAcDeviceManager(entry.data["username"], entry.data["password"])
+    device_manager = ToshibaAcDeviceManager(
+        entry.data["username"],
+        entry.data["password"],
+        entry.data["device_id"],
+        entry.data["sas_token"]
+    )
 
     try:
         await device_manager.connect()
-
     except Exception:
         return False
-
-    # if not await device_manager.connect():
-    #     return False
 
     hass.data[DOMAIN][entry.entry_id] = device_manager
 

--- a/custom_components/toshiba_ac/config_flow.py
+++ b/custom_components/toshiba_ac/config_flow.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import random
+
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -13,12 +15,11 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN
 
-# from .toshiba_ac_control.toshiba_ac.device_manager import ToshibaAcDeviceManager
 from toshiba_ac.device_manager import ToshibaAcDeviceManager
+from toshiba_ac.http_api import ToshibaAcHttpApiError, ToshibaAcHttpApiAuthError
 
 _LOGGER = logging.getLogger(__name__)
 
-# TODO adjust the data schema to the data that you need
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         # vol.Required("host"): str,
@@ -33,35 +34,25 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
-    # TODO validate the data can be used to set up a connection.
 
-    # If your PyPI package is not built with async, pass your methods
-    # to the executor:
-    # await hass.async_add_executor_job(
-    #     your_validate_func, data["username"], data["password"]
-    # )
+    device_id = f'{random.getrandbits(64):016x}'
 
-    # hub = PlaceholderHub(data["host"])
-
-    # if not await hub.authenticate(data["username"], data["password"]):
-    #     raise InvalidAuth
-
-    device_manager = ToshibaAcDeviceManager(data["username"], data["password"])
+    device_manager = ToshibaAcDeviceManager(data["username"], data["password"], device_id)
 
     try:
-        await device_manager.connect()
+        sas_token = await device_manager.connect()
 
-    except Exception:
-        # _LOGGER.debug("connect failed - for: " + data["username"] + "-" + data["password"])
+    except ToshibaAcHttpApiAuthError:
         raise InvalidAuth
+    except ToshibaAcHttpApiError:
+        raise CannotConnect
 
-    # If you cannot connect:
-    # throw CannotConnect
-    # If the authentication is wrong:
-    # InvalidAuth
-
-    # Return info that you want to store in the config entry.
-    return {"title": data["username"]}
+    return {
+        "username": data["username"],
+        "password": data["password"],
+        "device_id": device_id,
+        "sas_token": sas_token
+    }
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -69,10 +60,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    # Pick one of the available connection classes in homeassistant/config_entries.py
-    # This tells HA if it should be asking for updates, or it'll be notified of updates
-    # automatically. This example uses PUSH, as the dummy hub will notify HA of
-    # changes.
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
@@ -83,7 +70,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         try:
-            info = await validate_input(self.hass, user_input)
+            data = await validate_input(self.hass, user_input)
         except CannotConnect:
             errors["base"] = "cannot_connect"
         except InvalidAuth:
@@ -92,7 +79,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"
         else:
-            return self.async_create_entry(title=info["title"], data=user_input)
+            return self.async_create_entry(title=user_input["username"], data=data)
 
         return self.async_show_form(step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors)
 

--- a/custom_components/toshiba_ac/manifest.json
+++ b/custom_components/toshiba_ac/manifest.json
@@ -4,12 +4,12 @@
   "config_flow": true,
   "documentation": "https://github.com/h4de5/home-assistant-toshiba_ac",
   "issue_tracker": "https://github.com/h4de5/home-assistant-toshiba_ac/issues",
-  "requirements": ["toshiba-ac==0.1.3"],
+  "requirements": ["toshiba-ac==0.1.4"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},
   "dependencies": [],
   "codeowners": ["@h4de5"],
-  "version": "2021.8.6",
+  "version": "2021.8.7",
   "iot_class": "cloud_push"
 }

--- a/custom_components/toshiba_ac/manifest.json
+++ b/custom_components/toshiba_ac/manifest.json
@@ -4,12 +4,12 @@
   "config_flow": true,
   "documentation": "https://github.com/h4de5/home-assistant-toshiba_ac",
   "issue_tracker": "https://github.com/h4de5/home-assistant-toshiba_ac/issues",
-  "requirements": ["toshiba-ac==0.1.4"],
+  "requirements": ["toshiba-ac==0.1.5"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},
   "dependencies": [],
   "codeowners": ["@h4de5"],
-  "version": "2021.8.7",
+  "version": "2021.8.6",
   "iot_class": "cloud_push"
 }


### PR DESCRIPTION
This PR updates toshiba-ac to 0.1.4. This version speeds up initial configuration and initial connection of toshiba-ac.

Two new entries are added to config:
`device_id` - AMQP "username"
`sas_token` - AMQP "password"

Unfortunately I don't know how to handle this kind of config update in HA so this requires re-adding integration,

@h4de5 if you know how to do this, feel free to edit or create new PR with needed change.
