### PR TITLE
Fix adding of energy consumption sensor.

### DIFF
--- a/custom_components/toshiba_ac/climate.py
+++ b/custom_components/toshiba_ac/climate.py
@@ -387,7 +387,7 @@ class ToshibaClimate(ClimateEntity):
         if set_temperature is None:
             return
 
-        if hasattr(self._device, "ac_merit_a_feature") and self._device.ac_merit_a_feature == ToshibaAcFcuState.AcMeritAFeature.SAVE:
+        if hasattr(self._device, "ac_merit_a_feature") and self._device.ac_merit_a_feature == ToshibaAcFcuState.AcMeritAFeature.HEATING_8C:
             # upper limit for target temp
             if set_temperature > 15:
                 set_temperature = 15
@@ -437,14 +437,14 @@ class ToshibaClimate(ClimateEntity):
     @property
     def min_temp(self) -> float:
         """Return the minimum temperature."""
-        if hasattr(self._device, "ac_merit_a_feature") and self._device.ac_merit_a_feature == ToshibaAcFcuState.AcMeritAFeature.SAVE:
+        if hasattr(self._device, "ac_merit_a_feature") and self._device.ac_merit_a_feature == ToshibaAcFcuState.AcMeritAFeature.HEATING_8C:
             return convert_temperature(5, TEMP_CELSIUS, self.temperature_unit)
         return convert_temperature(17, TEMP_CELSIUS, self.temperature_unit)
 
     @property
     def max_temp(self) -> float:
         """Return the maximum temperature."""
-        if hasattr(self._device, "ac_merit_a_feature") and self._device.ac_merit_a_feature == ToshibaAcFcuState.AcMeritAFeature.SAVE:
+        if hasattr(self._device, "ac_merit_a_feature") and self._device.ac_merit_a_feature == ToshibaAcFcuState.AcMeritAFeature.HEATING_8C:
             return convert_temperature(15, TEMP_CELSIUS, self.temperature_unit)
         return convert_temperature(30, TEMP_CELSIUS, self.temperature_unit)
 

--- a/custom_components/toshiba_ac/manifest.json
+++ b/custom_components/toshiba_ac/manifest.json
@@ -4,12 +4,12 @@
   "config_flow": true,
   "documentation": "https://github.com/h4de5/home-assistant-toshiba_ac",
   "issue_tracker": "https://github.com/h4de5/home-assistant-toshiba_ac/issues",
-  "requirements": ["toshiba-ac==0.1.8"],
+  "requirements": ["toshiba-ac==0.1.10"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},
   "dependencies": [],
   "codeowners": ["@h4de5"],
-  "version": "2021.8.8",
+  "version": "2021.9.1",
   "iot_class": "cloud_push"
 }

--- a/custom_components/toshiba_ac/sensor.py
+++ b/custom_components/toshiba_ac/sensor.py
@@ -49,10 +49,14 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
         else:
             _LOGGER.info("AC device does not seem to support energy monitoring")
 
-        if device.ac_outdoor_temperature is not None and not outdoor_done:
+        # We cannot check for device.ac_outdoor_temperature not being None
+        # as it will report None when outdoor unit is off
+        # i.e. when AC is in Fan mode or Off
+        if not outdoor_done:
             sensor_entity = ToshibaTempSensor(device)
             new_devices.append(sensor_entity)
             outdoor_done = True
+
     # If we have any new devices, add them
     if new_devices:
         _LOGGER.info("Adding %d %s", len(new_devices), "sensors")


### PR DESCRIPTION
I have updated toshiba-ac to 0.1.10, beside making sure that energy is fetched before returning list of devices this version also adds some new properties to ToshibaAcDevice:
`supported_merit_a_features` - list of supported merit A features, available from beginning 
`supported_merit_b_features` - list of supported merit B features, available from beginning 
`is_pure_ion_supported` - bool indication if Pure ION feature is supported, available from beginning 
`firmware_version` - version of the firmware, available from beginning 
`cdu` - model of CDU unit, available after some time as it's fetched in the background. Notified by `on_state_changed_callback`
`fcu` - model of FCU unit, afailable after some time as it's fetched in the background. Notified by `on_state_changed_callback`