### PR TITLE
Migrate to attributes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+      {
+        // Example of attaching to local debug server
+        "name": "Python: Attach Local",
+        "type": "python",
+        "request": "attach",
+        "port": 5678,
+        "host": "localhost",
+        "pathMappings": [
+          {
+            "localRoot": "${workspaceFolder}",
+            "remoteRoot": "."
+          }
+        ]
+      },
+      {
+        // Example of attaching to my production server
+        "name": "Python: Attach Remote",
+        "type": "python",
+        "request": "attach",
+        "port": 5678,
+        "host": "homeassistant.local",
+        "pathMappings": [
+          {
+            "localRoot": "${workspaceFolder}",
+            "remoteRoot": "/usr/src/homeassistant"
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,27 @@
+{
+  "files.eol": "\n",
+  "editor.tabSize": 4,
+  "terminal.integrated.profiles.linux": {
+    "bash": {
+      "path": "/bin/bash"
+    }
+  },
+  "terminal.integrated.defaultProfile.linux": "bash",
+  "python.defaultInterpreterPath": "/usr/bin/python",
+  "python.testing.pytestEnabled": true,
+  "python.analysis.autoSearchPaths": false,
+  "python.linting.pylintEnabled": true,
+  "python.linting.enabled": true,
+  "python.formatting.provider": "black",
+  "editor.formatOnPaste": false,
+  "editor.formatOnSave": true,
+  "editor.formatOnType": true,
+  "files.trimTrailingWhitespace": true,
+  "files.associations": {
+    "*.yaml": "home-assistant"
+  },
+  "editor.defaultFormatter": null,
+  "[javascript, yaml, json, jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run Home Assistant on port 9123",
+            "type": "shell",
+            "command": "container start",
+            "problemMatcher": []
+        },
+        {
+            "label": "Run Home Assistant configuration against /config",
+            "type": "shell",
+            "command": "container check",
+            "problemMatcher": []
+        },
+        {
+            "label": "Upgrade Home Assistant to latest dev",
+            "type": "shell",
+            "command": "container install",
+            "problemMatcher": []
+        },
+        {
+            "label": "Install a specific version of Home Assistant",
+            "type": "shell",
+            "command": "container set-version",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/custom_components/toshiba_ac/entity.py
+++ b/custom_components/toshiba_ac/entity.py
@@ -1,0 +1,31 @@
+"""Parent class for every Toshiba AC device."""
+
+from __future__ import annotations
+
+from toshiba_ac.device import ToshibaAcDevice
+
+from homeassistant.helpers.entity import DeviceInfo, Entity
+
+from .const import DOMAIN
+
+
+class ToshibaAcEntity(Entity):
+    """Representation of an Toshiba AC device entity."""
+
+    def __init__(self, toshiba_device: ToshibaAcDevice) -> None:
+        """Initialize the device."""
+        self._device = toshiba_device
+
+        self._attr_should_poll = False
+        self._attr_device_info = self.generate_device_info()
+
+    def generate_device_info(self) -> DeviceInfo:
+        """Information about this entity/device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device.ac_unique_id)},
+            account=self._device.ac_id,
+            device_id=self._device.device_id,
+            manufacturer="Toshiba",
+            name=self._device.name,
+            sw_version=self._device.firmware_version,
+        )


### PR DESCRIPTION
Since several releases now, in order to ease code and number of lines, various `_attr_*` are available.

See [here](https://github.com/home-assistant/core/blob/fe17f97543b99f88993ebcb7fa15be0dfe5c43c7/homeassistant/components/climate/__init__.py#L181) for climate
 and [here](https://github.com/home-assistant/core/blob/fe17f97543b99f88993ebcb7fa15be0dfe5c43c7/homeassistant/helpers/entity.py#L269) for the common ones