### PR TITLE
Update minimum HA required version

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,5 @@
   "name": "Toshiba AC",
   "content_in_root": false,
   "render_readme": true,
-  "homeassistant": "2022.5.0"
+  "homeassistant": "2022.11.0"
 }


### PR DESCRIPTION
I forgot to update this file with my latest fix and update instead the manifest. 

Fix https://github.com/h4de5/home-assistant-toshiba_ac/issues/97