### PR TITLE
Fix async_unload_entry

### DIFF
--- a/custom_components/toshiba_ac/__init__.py
+++ b/custom_components/toshiba_ac/__init__.py
@@ -46,7 +46,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN][entry.entry_id].shutdown()
+        await hass.data[DOMAIN][entry.entry_id].shutdown()
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok


### PR DESCRIPTION
[shutdown](https://github.com/KaSroka/Toshiba-AC-control/blob/master/toshiba_ac/device_manager.py#L75) is an async method and must be awaited. 

I detected this while I removed the integration from my dev HA, an error was raised.