### PR TITLE
Move available property to base class, feature_list.py, ToshibaAcStateEntity

### DIFF
--- a/custom_components/toshiba_ac/climate.py
+++ b/custom_components/toshiba_ac/climate.py
@@ -25,7 +25,8 @@ from homeassistant.components.climate.const import (
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 
 from .const import DOMAIN
-from .entity import ToshibaAcEntity
+from .entity import ToshibaAcStateEntity
+from .feature_list import get_feature_by_name, get_feature_list
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,19 +44,19 @@ HVAC_MODE_TO_TOSHIBA = {v: k for k, v in TOSHIBA_TO_HVAC_MODE.items()}
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Add climate for passed config_entry in HA."""
     device_manager = hass.data[DOMAIN][config_entry.entry_id]
-    new_devices = []
+    new_entities = []
 
     devices = await device_manager.get_devices()
     for device in devices:
         climate_entity = ToshibaClimate(device)
-        new_devices.append(climate_entity)
-    # If we have any new devices, add them
-    if new_devices:
-        _LOGGER.info("Adding %d %s", len(new_devices), "climates")
-        async_add_devices(new_devices)
+        new_entities.append(climate_entity)
+
+    if new_entities:
+        _LOGGER.info("Adding %d %s", len(new_entities), "climates")
+        async_add_devices(new_entities)
 
 
-class ToshibaClimate(ToshibaAcEntity, ClimateEntity):
+class ToshibaClimate(ToshibaAcStateEntity, ClimateEntity):
     """Provides a Toshiba climates."""
 
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
@@ -73,72 +74,8 @@ class ToshibaClimate(ToshibaAcEntity, ClimateEntity):
         self._attr_unique_id = f"{self._device.ac_unique_id}_climate"
         self._attr_name = self._device.name
         self._attr_target_temperature_step = 1
-        self._attr_fan_modes = self.get_feature_list(self._device.supported.ac_fan_mode)
-        self._attr_swing_modes = self.get_feature_list(
-            self._device.supported.ac_swing_mode
-        )
-        # _LOGGER.debug("###########################")
-        # _LOGGER.debug(
-        #     "Supported features: ac_mode %s, ac_swing_mode %s, ac_merit_b %s, ac_merit_a %s, ac_energy_report %s",
-        #     self._device.supported.ac_mode,
-        #     self._device.supported.ac_swing_mode,
-        #     self._device.supported.ac_merit_b,
-        #     self._device.supported.ac_merit_a,
-        #     # self._device.supported.ac_pure_ion,
-        #     self._device.supported.ac_energy_report,
-        # )
-
-        # # _LOGGER.debug("Test get current power selection %s", self._device.ac_power_selection)
-        # # _LOGGER.debug("Test get list of power selections %s", list(ToshibaAcPowerSelection))
-
-        # # ac_power_selection_nice = [pretty_enum_name(e) for e in self._device.supported.ac_swing_mode]
-
-        # # self._device.supported.ac_swing_mode
-
-        # _LOGGER.debug("Test get list of swing modes %s", self.get_feature_list(self._device.supported.ac_swing_mode))
-
-        # # _LOGGER.debug(
-        # #     "Test get list of swing modes %s %s",
-        # #     self._device.supported.ac_swing_mode,
-        # #     list(self._device.supported.ac_swing_mode),
-        # # )
-
-        # _LOGGER.debug("###########################")
-
-        # ToshibaEntity.__init__(self, device_id, toshibaconnection, toshibaproject, coordinator)
-        # self.entity_id = "climate." + self._name.lower() + "_" + self._device_id
-
-    # default entity properties
-
-    async def state_changed(self, dev):
-        """Whenever state should change."""
-        self.async_write_ha_state()
-
-    async def async_added_to_hass(self):
-        """Run when this Entity has been added to HA."""
-        # Importantly for a push integration, the module that will be getting updates
-        # needs to notify HA of changes. The dummy device has a registercallback
-        # method, so to this we add the 'self.async_write_ha_state' method, to be
-        # called where ever there are changes.
-        # The call back registration is done once this entity is registered with HA
-        # (rather than in the __init__)
-        # self._device.register_callback(self.async_write_ha_state)
-        self._device.on_state_changed_callback.add(self.state_changed)
-
-    async def async_will_remove_from_hass(self):
-        """Entity being removed from hass."""
-        # The opposite of async_added_to_hass. Remove any registered call backs here.
-        # self._device.remove_callback(self.async_write_ha_state)
-        self._device.on_state_changed_callback.remove(self.state_changed)
-
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return (
-            self._device.ac_id
-            and self._device.amqp_api.sas_token
-            and self._device.http_api.access_token
-        )
+        self._attr_fan_modes = get_feature_list(self._device.supported.ac_fan_mode)
+        self._attr_swing_modes = get_feature_list(self._device.supported.ac_swing_mode)
 
     @property
     def is_on(self):
@@ -192,13 +129,13 @@ class ToshibaClimate(ToshibaAcEntity, ClimateEntity):
 
         Requires SUPPORT_PRESET_MODE.
         """
-        return self.get_feature_list(self._device.supported.ac_power_selection)
+        return get_feature_list(self._device.supported.ac_power_selection)
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
         _LOGGER.info("Toshiba Climate setting preset_mode: %s", preset_mode)
 
-        feature_list_id = self.get_feature_list_id(
+        feature_list_id = get_feature_by_name(
             list(ToshibaAcPowerSelection), preset_mode
         )
         if feature_list_id is not None:
@@ -241,7 +178,7 @@ class ToshibaClimate(ToshibaAcEntity, ClimateEntity):
             if not self.is_on:
                 await self._device.set_ac_status(ToshibaAcStatus.ON)
 
-            feature_list_id = self.get_feature_list_id(list(ToshibaAcFanMode), fan_mode)
+            feature_list_id = get_feature_by_name(list(ToshibaAcFanMode), fan_mode)
             if feature_list_id is not None:
                 await self._device.set_ac_fan_mode(feature_list_id)
 
@@ -252,7 +189,7 @@ class ToshibaClimate(ToshibaAcEntity, ClimateEntity):
 
     async def async_set_swing_mode(self, swing_mode: str) -> None:
         """Set new target swing operation."""
-        feature_list_id = self.get_feature_list_id(list(ToshibaAcSwingMode), swing_mode)
+        feature_list_id = get_feature_by_name(list(ToshibaAcSwingMode), swing_mode)
         if feature_list_id is not None:
             await self._device.set_ac_swing_mode(feature_list_id)
 
@@ -305,20 +242,3 @@ class ToshibaClimate(ToshibaAcEntity, ClimateEntity):
             "self_cleaning": self._device.ac_self_cleaning.name,
             "outdoor_temperature": self._device.ac_outdoor_temperature,
         }
-
-    def get_feature_list(self, feature_list: list[Any]) -> list[Any]:
-        """Return a list of features supported by the device."""
-        return [
-            pretty_enum_name(e) for e in feature_list if pretty_enum_name(e) != "None"
-        ]
-
-    def get_feature_list_id(self, feature_list: list[Any], feature_name: str) -> Any:
-        """Return the enum value of that item with the given name from a feature list."""
-        _LOGGER.debug("searching %s for %s", feature_list, feature_name)
-
-        feature_list = [e for e in feature_list if pretty_enum_name(e) == feature_name]
-        _LOGGER.debug("and found %s", feature_list)
-
-        if len(feature_list) > 0:
-            return feature_list[0]
-        return None

--- a/custom_components/toshiba_ac/feature_list.py
+++ b/custom_components/toshiba_ac/feature_list.py
@@ -1,0 +1,29 @@
+"""Helpers for converting enums to strings"""
+
+from enum import Enum
+import logging
+from typing import Any, TypeVar
+
+from toshiba_ac.utils import pretty_enum_name
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def get_feature_list(feature_list: list[Any]) -> list[str]:
+    """Return a list of features supported by the device."""
+    return [pretty_enum_name(e) for e in feature_list if pretty_enum_name(e) != "None"]
+
+
+T = TypeVar("T", bound=Enum)
+
+
+def get_feature_by_name(feature_list: list[T], feature_name: str) -> T | None:
+    """Return the enum value of that item with the given name from a feature list."""
+    _LOGGER.debug("searching %s for %s", feature_list, feature_name)
+
+    feature_list = [e for e in feature_list if pretty_enum_name(e) == feature_name]
+    _LOGGER.debug("and found %s", feature_list)
+
+    if len(feature_list) > 0:
+        return feature_list[0]
+    return None

--- a/custom_components/toshiba_ac/sensor.py
+++ b/custom_components/toshiba_ac/sensor.py
@@ -6,7 +6,6 @@ import logging
 
 from toshiba_ac.device import ToshibaAcDevice, ToshibaAcDeviceEnergyConsumption
 
-from custom_components.toshiba_ac.entity import ToshibaAcEntity
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -16,6 +15,7 @@ from homeassistant.const import ENERGY_WATT_HOUR, TEMP_CELSIUS
 from homeassistant.helpers.typing import StateType
 
 from .const import DOMAIN
+from .entity import ToshibaAcEntity, ToshibaAcStateEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,7 +35,6 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 
     devices: list[ToshibaAcDevice] = await device_manager.get_devices()
     for device in devices:
-
         # _LOGGER.debug("device %s", device)
         # _LOGGER.debug("energy_consumption %s", device.ac_energy_consumption)
 
@@ -64,19 +63,15 @@ class ToshibaPowerSensor(ToshibaAcEntity, SensorEntity):
     _attr_native_unit_of_measurement = ENERGY_WATT_HOUR
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _ac_energy_consumption: ToshibaAcDeviceEnergyConsumption | None = None
 
     def __init__(self, toshiba_device: ToshibaAcDevice):
         """Initialize the sensor."""
         super().__init__(toshiba_device)
-
-        self._ac_energy_consumption: ToshibaAcDeviceEnergyConsumption = None
-
         self._attr_unique_id = f"{self._device.ac_unique_id}_sensor"
         self._attr_name = f"{self._device.name} Power Consumption"
 
-    # default entity properties
-
-    async def state_changed(self, dev):
+    async def state_changed(self, _dev: ToshibaAcDevice):
         """Call if we need to change the ha state."""
         self._ac_energy_consumption = self._device.ac_energy_consumption
         self.async_write_ha_state()
@@ -99,15 +94,6 @@ class ToshibaPowerSensor(ToshibaAcEntity, SensorEntity):
         self._device.on_energy_consumption_changed_callback.remove(self.state_changed)
 
     @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return (
-            self._device.ac_id
-            and self._device.amqp_api.sas_token
-            and self._device.http_api.access_token
-        )
-
-    @property
     def native_value(self) -> StateType | date | datetime:
         """Return the value reported by the sensor."""
         if self._ac_energy_consumption:
@@ -119,9 +105,10 @@ class ToshibaPowerSensor(ToshibaAcEntity, SensorEntity):
         """Return the state attributes."""
         if self._ac_energy_consumption:
             return {"last_reset": self._ac_energy_consumption.since}
+        return {}
 
 
-class ToshibaTempSensor(ToshibaAcEntity, SensorEntity):
+class ToshibaTempSensor(ToshibaAcStateEntity, SensorEntity):
     """Provides a Toshiba Temperature Sensors."""
 
     _attr_native_unit_of_measurement = TEMP_CELSIUS
@@ -136,18 +123,6 @@ class ToshibaTempSensor(ToshibaAcEntity, SensorEntity):
         self._attr_unique_id = f"{self._device.ac_unique_id}_outdoor_temperature"
         self._attr_name = f"{self._device.name} Outdoor Temperature"
 
-    async def state_changed(self, dev):
-        """Call if we need to change the ha state."""
-        self.async_write_ha_state()
-
-    async def async_added_to_hass(self):
-        """Run when this Entity has been added to HA."""
-        self._device.on_state_changed_callback.add(self.state_changed)
-
-    async def async_will_remove_from_hass(self):
-        """Entity being removed from hass."""
-        self._device.on_state_changed_callback.remove(self.state_changed)
-
     @property
     def available(self) -> bool:
         """Return True if sensor is available."""
@@ -155,11 +130,7 @@ class ToshibaTempSensor(ToshibaAcEntity, SensorEntity):
             self._device.ac_outdoor_temperature
             or self._device.ac_outdoor_temperature == 0
         ):
-            return (
-                self._device.ac_id
-                and self._device.amqp_api.sas_token
-                and self._device.http_api.access_token
-            )
+            return super().available
         return False
 
     @property

--- a/custom_components/toshiba_ac/switch.py
+++ b/custom_components/toshiba_ac/switch.py
@@ -1,19 +1,18 @@
-"""Platform for sensor integration."""
+"""Switch platform for the Toshiba AC integration."""
 from __future__ import annotations
 
 import logging
 from typing import Any
 
+from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from toshiba_ac.device import (
     ToshibaAcDevice,
     ToshibaAcStatus,
     ToshibaAcAirPureIon,
 )
 
-from custom_components.toshiba_ac.entity import ToshibaAcEntity
-from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
-
 from .const import DOMAIN
+from .entity import ToshibaAcStateEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,26 +20,26 @@ _LOGGER = logging.getLogger(__name__)
 # This function is called as part of the __init__.async_setup_entry (via the
 # hass.config_entries.async_forward_entry_setup call)
 async def async_setup_entry(hass, config_entry, async_add_devices):
-    """Add sensor for passed config_entry in HA."""
+    """Add all sensors for passed config_entry in HA."""
     # The hub is loaded from the associated hass.data entry that was created in the
     # __init__.async_setup_entry function
     device_manager = hass.data[DOMAIN][config_entry.entry_id]
-    new_devices = []
+    new_entites = []
 
     devices: list[ToshibaAcDevice] = await device_manager.get_devices()
     for device in devices:
         if ToshibaAcAirPureIon.ON in device.supported.ac_air_pure_ion:
             switch_entity = ToshibaAirPureIonSwitch(device)
-            new_devices.append(switch_entity)
+            new_entites.append(switch_entity)
         else:
             _LOGGER.info("AC device does not support air purification")
 
-    if new_devices:
-        _LOGGER.info("Adding %d %s", len(new_devices), "switches")
-        async_add_devices(new_devices)
+    if new_entites:
+        _LOGGER.info("Adding %d %s", len(new_entites), "switches")
+        async_add_devices(new_entites)
 
 
-class ToshibaAirPureIonSwitch(ToshibaAcEntity, SwitchEntity):
+class ToshibaAirPureIonSwitch(ToshibaAcStateEntity, SwitchEntity):
     """Provides a switch to toggle the air purifier."""
 
     _attr_device_class = SwitchDeviceClass.SWITCH
@@ -51,37 +50,19 @@ class ToshibaAirPureIonSwitch(ToshibaAcEntity, SwitchEntity):
 
         self._attr_unique_id = f"{self._device.ac_unique_id}_air_purifier"
         self._attr_name = f"{self._device.name} Air Purifier"
-        self._update_state()
-
-    async def async_added_to_hass(self):
-        """Run when this Entity has been added to HA."""
-        self._device.on_state_changed_callback.add(self._state_changed)
-
-    async def async_will_remove_from_hass(self):
-        """Entity being removed from hass."""
-        self._device.on_state_changed_callback.remove(self._state_changed)
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        await self._device.set_ac_air_pure_ion(ToshibaAcAirPureIon.OFF)
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        await self._device.set_ac_air_pure_ion(ToshibaAcAirPureIon.ON)
-
-    async def _state_changed(self, _dev: ToshibaAcDevice):
-        """Call if we need to change the ha state."""
-        self._update_state()
-        self.async_write_ha_state()
-
-    def _update_state(self) -> None:
-        self._attr_is_on = self._device.ac_air_pure_ion == ToshibaAcAirPureIon.ON
-        self._attr_icon = "mdi:air-purifier" if self.is_on else "mdi:air-purifier-off"
+        self.update_attrs()
 
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return bool(
-            self._device.ac_id
-            and self._device.amqp_api.sas_token
-            and self._device.http_api.access_token
-            and self._device.ac_status == ToshibaAcStatus.ON
-        )
+        return super().available and self._device.ac_status == ToshibaAcStatus.ON
+
+    async def async_turn_off(self, **kwargs: Any):
+        await self._device.set_ac_air_pure_ion(ToshibaAcAirPureIon.OFF)
+
+    async def async_turn_on(self, **kwargs: Any):
+        await self._device.set_ac_air_pure_ion(ToshibaAcAirPureIon.ON)
+
+    def update_attrs(self):
+        self._attr_is_on = self._device.ac_air_pure_ion == ToshibaAcAirPureIon.ON
+        self._attr_icon = "mdi:air-purifier" if self.is_on else "mdi:air-purifier-off"


### PR DESCRIPTION
Small refactoring before I tackle all the other entities.
- [x] Move `available` to `ToshibaAcEntity` because all the entities check for the API availability.
- [x] Move `get_feature_list` etc. to its own file, fix typings
- [x] Create new `ToshibaAcStateEntity` base class for entities that listen to the state changed event (all except power consumption sensor)