### PR TITLE
added a fix for Home Assistant 2024.1.0

### DIFF
--- a/custom_components/toshiba_ac/select.py
+++ b/custom_components/toshiba_ac/select.py
@@ -106,6 +106,7 @@ _SELECT_DESCRIPTIONS: Sequence[ToshibaAcSelectDescription] = [
     ToshibaAcEnumSelectDescription(
         key="cdu_silent",
         icon="mdi:home-sound-in-outline",
+        icon_mapping={},
         translation_key="cdu_silent",
         ac_attr_name="ac_merit_a",
         values=[


### PR DESCRIPTION
One of the calls to `ToshibaAcEnumSelectDescription.__init__()` in `_SELECT_DESCRIPTIONS` was missing an `icon_mapping` parameter which started causing issues on Home Assistant 2024.1.0. I've added the missing parameter which has fixed the issue. Another option would have been to mark the field as optional but this was a simpler change (I'm not an experienced Python dev, most of my work is in TypeScript).

I've tested this change on my local instance and it fixes the issue.