### PR TITLE
Updated deprecated constants which will be removed in HA Core 2025.1

### DIFF
--- a/custom_components/toshiba_ac/sensor.py
+++ b/custom_components/toshiba_ac/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
 )
-from homeassistant.const import ENERGY_WATT_HOUR, TEMP_CELSIUS
+from homeassistant.const import UnitOfEnergy, UnitOfTemperature
 from homeassistant.helpers.typing import StateType
 
 from .const import DOMAIN
@@ -60,7 +60,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 class ToshibaPowerSensor(ToshibaAcEntity, SensorEntity):
     """Provides a Toshiba Sensors."""
 
-    _attr_native_unit_of_measurement = ENERGY_WATT_HOUR
+    _attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _ac_energy_consumption: ToshibaAcDeviceEnergyConsumption | None = None
@@ -111,7 +111,7 @@ class ToshibaPowerSensor(ToshibaAcEntity, SensorEntity):
 class ToshibaTempSensor(ToshibaAcStateEntity, SensorEntity):
     """Provides a Toshiba Temperature Sensors."""
 
-    _attr_native_unit_of_measurement = TEMP_CELSIUS
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_has_entity_name = True


### PR DESCRIPTION
This should fix the following errors in the log mentioned in issue #168:

> Logger: homeassistant.const
Source: helpers/deprecation.py:206
• ENERGY_WATT_HOUR was used from toshiba_ac, this is a deprecated constant which will be removed in HA Core 2025.1. Use
UnitOfEnergy.WATT_HOUR instead, please report it to the author of the 'toshiba_ac' custom integration
• TEMP_CELSIUS was used from toshiba_ac, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead, please report it to the author of the 'toshiba_ac custom integration