### PR TITLE
Request new sas_token if connection fails

### DIFF
--- a/custom_components/toshiba_ac/__init__.py
+++ b/custom_components/toshiba_ac/__init__.py
@@ -39,9 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.warning("Initial connection failed, trying to get new sas_token...")
         # If it fails to connect, try to get a new sas_token
         device_manager = ToshibaAcDeviceManager(
-            entry.data["username"],
-            entry.data["password"],
-            entry.data["device_id"]
+            entry.data["username"], entry.data["password"], entry.data["device_id"]
         )
 
         try:

--- a/custom_components/toshiba_ac/__init__.py
+++ b/custom_components/toshiba_ac/__init__.py
@@ -1,5 +1,6 @@
 """The Toshiba AC integration."""
 from __future__ import annotations
+
 import logging
 
 from toshiba_ac.device_manager import ToshibaAcDeviceManager


### PR DESCRIPTION
It seems that Toshiba has expired the internal authorization tokens used by this integration. Currently, there is a flaw in the design of this integration which means that the token will never get renewed, even if it has expired.

This PR adds the ability for the integration to automatically renew and save new tokens and fixes this problem for good.

Fix for https://github.com/h4de5/home-assistant-toshiba_ac/issues/188