### PR TITLE
Update toshiba-ac to 0.3.11

### DIFF
--- a/custom_components/toshiba_ac/manifest.json
+++ b/custom_components/toshiba_ac/manifest.json
@@ -8,7 +8,10 @@
   "homekit": {},
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/h4de5/home-assistant-toshiba_ac/issues",
-  "requirements": ["toshiba-ac==0.3.10","janus==1.0.0"],
+  "requirements": [
+    "toshiba-ac@git+https://github.com/KaSroka/Toshiba-AC-control@0.3.11",
+    "janus==1.0.0"
+  ],
   "ssdp": [],
   "version": "2024.12.0",
   "zeroconf": []


### PR DESCRIPTION
As toshiba-ac uses github link for azure-iot-device dependency, we have to use github link in manifest file as well.