### PR TITLE
Retry and reconnect

### DIFF
--- a/custom_components/toshiba_ac/__init__.py
+++ b/custom_components/toshiba_ac/__init__.py
@@ -91,6 +91,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.error("Unload Toshiba integration")
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
+        setup_task = hass.data[DOMAIN].pop(f"{entry.entry_id}_setup_task", None)
+        if setup_task is not None and not setup_task.done():
+            setup_task.cancel()
+
         device_manager: ToshibaAcDeviceManager = hass.data[DOMAIN][entry.entry_id]
         try:
             await device_manager.shutdown()

--- a/custom_components/toshiba_ac/diagnostics.py
+++ b/custom_components/toshiba_ac/diagnostics.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+TO_REDACT = {"username", "password", "token", "refresh_token", "serial", "mac"}
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    data: dict[str, Any] = {
+        "entry": {
+            "entry_id": entry.entry_id,
+            "title": entry.title,
+            "data": async_redact_data(dict(entry.data), TO_REDACT),
+            "options": dict(entry.options),
+            "state": str(entry.state),
+        },
+        "devices": [],
+    }
+
+    device_manager = hass.data[DOMAIN].get(entry.entry_id)
+    if device_manager is None:
+        return data
+
+    try:
+        devices = await device_manager.get_devices()
+    except Exception as exc:  # pragma: no cover - best-effort
+        data["error"] = repr(exc)
+        return data
+
+    for dev in devices:
+        data["devices"].append(
+            async_redact_data(
+                {
+                    "name": getattr(dev, "name", None),
+                    "unique_id": getattr(dev, "ac_unique_id", None),
+                    "supported": getattr(dev, "supported", None).__dict__
+                    if getattr(dev, "supported", None)
+                    else None,
+                    "status": {
+                        "ac_status": getattr(dev, "ac_status", None).name if getattr(dev, "ac_status", None) else None,
+                        "mode": getattr(dev, "ac_mode", None).name if getattr(dev, "ac_mode", None) else None,
+                        "temp": getattr(dev, "ac_temperature", None),
+                        "indoor_temp": getattr(dev, "ac_indoor_temperature", None),
+                        "outdoor_temp": getattr(dev, "ac_outdoor_temperature", None),
+                    },
+                },
+                TO_REDACT,
+            )
+        )
+    return data

--- a/custom_components/toshiba_ac/services.yaml
+++ b/custom_components/toshiba_ac/services.yaml
@@ -1,0 +1,4 @@
+reconnect:
+  name: Reconnect to Toshiba AC
+  description: Force reconnection to Toshiba AC service and reload the integration. Use this if you're experiencing connection issues or authentication problems.
+  fields: {}

--- a/custom_components/toshiba_ac/switch.py
+++ b/custom_components/toshiba_ac/switch.py
@@ -1,6 +1,7 @@
 """Switch platform for the Toshiba AC integration."""
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
@@ -129,26 +130,59 @@ _SWITCH_DESCRIPTIONS: Sequence[ToshibaAcSwitchDescription] = [
 # hass.config_entries.async_forward_entry_setup call)
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Add all sensors for passed config_entry in HA."""
-    # The hub is loaded from the associated hass.data entry that was created in the
-    # __init__.async_setup_entry function
     device_manager = hass.data[DOMAIN][config_entry.entry_id]
-    new_entites = []
 
-    devices: list[ToshibaAcDevice] = await device_manager.get_devices()
-    for device in devices:
-        for entity_description in _SWITCH_DESCRIPTIONS:
-            if entity_description.is_supported(device.supported):
-                new_entites.append(ToshibaAcSwitchEntity(device, entity_description))
-            else:
-                _LOGGER.info(
-                    "AC device %s does not support %s",
-                    device.name,
-                    entity_description.key,
+    async def _run_setup():
+        backoff = [1, 3, 7, 30, 60, 300, 1800]
+        attempt = 0
+        while True:
+            try:
+                devices: list[ToshibaAcDevice] = await device_manager.get_devices()
+                new_entities = []
+
+                for device in devices:
+                    for entity_description in _SWITCH_DESCRIPTIONS:
+                        if entity_description.is_supported(device.supported):
+                            new_entities.append(ToshibaAcSwitchEntity(device, entity_description))
+                        else:
+                            _LOGGER.info(
+                                "AC device %s does not support %s",
+                                device.name,
+                                entity_description.key,
+                            )
+
+                if new_entities:
+                    _LOGGER.info("Adding %d %s", len(new_entities), "switches")
+                    async_add_devices(new_entities)
+                return
+            except Exception as ex:
+                wait = backoff[min(attempt, len(backoff) - 1)]
+                attempt += 1
+                _LOGGER.warning(
+                    "Toshiba AC: switch setup attempt %s failed: %r. Retrying in %s sec",
+                    attempt,
+                    ex,
+                    wait,
                 )
 
-    if new_entites:
-        _LOGGER.info("Adding %d %s", len(new_entites), "switches")
-        async_add_devices(new_entites)
+                # Try to reconnect on specific failures that might indicate token issues
+                if attempt == 1 and ("403" in str(ex) or "Forbidden" in str(ex) or "TimeoutError" in str(ex)):
+                    _LOGGER.info("Attempting to refresh connection due to potential token issue")
+                    try:
+                        await device_manager.connect()
+                        _LOGGER.info("Successfully refreshed connection")
+                        # Reset wait time for immediate retry after successful reconnect
+                        wait = 1
+                    except Exception as connect_ex:
+                        _LOGGER.warning("Failed to refresh connection: %r", connect_ex)
+
+                await asyncio.sleep(wait)
+
+    async def _start_setup_task():
+        task = hass.loop.create_task(_run_setup())
+        hass.data[DOMAIN][f"{config_entry.entry_id}_switch_setup_task"] = task
+
+    await _start_setup_task()
 
 
 class ToshibaAcSwitchEntity(ToshibaAcStateEntity, SwitchEntity):


### PR DESCRIPTION
Since the Toshiba SAS token often expires, this is a better retry logic, which should support recovery in case of SAS token expiration and retries in case of backend errors.

I tested this a bit, but I would like the community to give it a try as well before merging. Works for me though.