### PR TITLE
Add retry/reconnect logic and improve HA integration

### DIFF
--- a/custom_components/toshiba_ac/__init__.py
+++ b/custom_components/toshiba_ac/__init__.py
@@ -7,7 +7,8 @@ import logging
 from toshiba_ac.device_manager import ToshibaAcDeviceManager
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 
 from .const import DOMAIN
 
@@ -16,34 +17,9 @@ PLATFORMS = ["climate", "select", "sensor", "switch"]
 _LOGGER = logging.getLogger(__name__)
 
 
-async def sas_token_updated_for_entry(
-    hass: HomeAssistant, entry: ConfigEntry, new_sas_token: str
-):
-    """Update SAS token."""
-    _LOGGER.info("SAS token updated")
-
-    new_data = {**entry.data, "sas_token": new_sas_token}
-    hass.config_entries.async_update_entry(entry, data=new_data)
-
-
-def add_sas_token_updated_callback_for_entry(
-    hass: HomeAssistant, entry: ConfigEntry, device_manager: ToshibaAcDeviceManager
-):
-    """Set up SAS token update callback."""
-
-    async def wrapper_callback(new_sas_token: str):
-        await sas_token_updated_for_entry(hass, entry, new_sas_token)
-
-    device_manager.on_sas_token_updated_callback.add(wrapper_callback)
-
-
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the Hello World component."""
-    # Ensure our name space for storing objects is a known type. A dict is
-    # common/preferred as it allows a separate instance of your class for each
-    # instance that has been created in the UI.
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Set up the Toshiba AC component."""
     hass.data.setdefault(DOMAIN, {})
-
     return True
 
 
@@ -53,49 +29,73 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.data["username"],
         entry.data["password"],
         entry.data["device_id"],
-        entry.data["sas_token"],
+        entry.data.get("sas_token"),
     )
 
     try:
-        await device_manager.connect()
-    except Exception:
-        _LOGGER.warning("Initial connection failed, trying to get new sas_token...")
-        # If it fails to connect, try to get a new sas_token
-        device_manager = ToshibaAcDeviceManager(
-            entry.data["username"], entry.data["password"], entry.data["device_id"]
-        )
-
-        try:
-            new_sas_token = await device_manager.connect()
-
-            _LOGGER.info("Successfully got new sas_token!")
-
-            # Save new sas_token
+        new_sas_token = await device_manager.connect()
+        # Save updated SAS token if we got a new one
+        if new_sas_token and new_sas_token != entry.data.get("sas_token"):
+            _LOGGER.info("SAS token updated during connection")
             new_data = {**entry.data, "sas_token": new_sas_token}
             hass.config_entries.async_update_entry(entry, data=new_data)
-        except Exception:
-            _LOGGER.warning("Connection failed on second try, aborting!")
-            return False
+    except Exception as ex:
+        error_str = str(ex).lower()
+        # Check for authentication-related errors
+        if "401" in error_str or "403" in error_str or "auth" in error_str:
+            raise ConfigEntryAuthFailed(
+                f"Authentication failed: {ex}. Please reconfigure the integration."
+            ) from ex
+        # For other errors, let HA retry with exponential backoff
+        raise ConfigEntryNotReady(f"Failed to connect to Toshiba AC service: {ex}") from ex
 
-    add_sas_token_updated_callback_for_entry(hass, entry, device_manager)
+    # Set up SAS token update callback
+    async def sas_token_updated(new_sas_token: str) -> None:
+        """Handle SAS token update from the device manager."""
+        _LOGGER.info("SAS token updated by device manager")
+        new_data = {**entry.data, "sas_token": new_sas_token}
+        hass.config_entries.async_update_entry(entry, data=new_data)
 
+    device_manager.on_sas_token_updated_callback.add(sas_token_updated)
+
+    # Store device manager
     hass.data[DOMAIN][entry.entry_id] = device_manager
 
+    # Register reconnect service (once per domain)
+    await _async_register_services(hass)
+
+    # Forward setup to platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
+async def _async_register_services(hass: HomeAssistant) -> None:
+    """Register integration services."""
+    if hass.services.has_service(DOMAIN, "reconnect"):
+        return
+
+    async def handle_reconnect(call: ServiceCall) -> None:
+        """Handle the reconnect service call."""
+        _LOGGER.info("Reconnect service called - reloading all config entries")
+        # Reload all config entries for this domain
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            await hass.config_entries.async_reload(entry.entry_id)
+
+    hass.services.async_register(DOMAIN, "reconnect", handle_reconnect)
+
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    _LOGGER.error("Unload Toshiba integration")
+    _LOGGER.info("Unloading Toshiba AC integration")
+
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
     if unload_ok:
-        device_manager: ToshibaAcDeviceManager = hass.data[DOMAIN][entry.entry_id]
+        device_manager: ToshibaAcDeviceManager = hass.data[DOMAIN].pop(entry.entry_id)
         try:
             await device_manager.shutdown()
         except Exception as ex:
-            _LOGGER.error("Error while unloading Toshiba integration %s", ex)
-        hass.data[DOMAIN].pop(entry.entry_id)
+            _LOGGER.warning("Error while shutting down device manager: %s", ex)
 
     return unload_ok

--- a/custom_components/toshiba_ac/__init__.py
+++ b/custom_components/toshiba_ac/__init__.py
@@ -47,7 +47,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 f"Authentication failed: {ex}. Please reconfigure the integration."
             ) from ex
         # For other errors, let HA retry with exponential backoff
-        raise ConfigEntryNotReady(f"Failed to connect to Toshiba AC service: {ex}") from ex
+        raise ConfigEntryNotReady(
+            f"Failed to connect to Toshiba AC service: {ex}"
+        ) from ex
 
     # Set up SAS token update callback
     async def sas_token_updated(new_sas_token: str) -> None:

--- a/custom_components/toshiba_ac/climate.py
+++ b/custom_components/toshiba_ac/climate.py
@@ -90,7 +90,7 @@ class ToshibaClimate(ToshibaAcStateEntity, ClimateEntity):
         """Set new target temperature."""
         set_temperature = kwargs[ATTR_TEMPERATURE]
 
-        # if hasattr(self._device, "ac_merit_a") and ToshibaAcMeritA.HEATING_8C in self._device.supported.ac_merit_a:
+        # Check if HEATING_8C mode is active (not just supported)
         if (
             hasattr(self._device, "ac_merit_a")
             and self._device.ac_merit_a == ToshibaAcMeritA.HEATING_8C

--- a/custom_components/toshiba_ac/climate.py
+++ b/custom_components/toshiba_ac/climate.py
@@ -24,7 +24,6 @@ from homeassistant.components.climate.const import (
     HVACMode,
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
-from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import DOMAIN
 from .entity import ToshibaAcStateEntity
@@ -44,21 +43,14 @@ HVAC_MODE_TO_TOSHIBA = {v: k for k, v in TOSHIBA_TO_HVAC_MODE.items()}
 
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
-    """Add climate for passed config_entry in HA."""
+    """Add climate entities for passed config_entry in HA."""
     device_manager = hass.data[DOMAIN][config_entry.entry_id]
-    new_entities = []
 
-    try:
-        devices = await device_manager.get_devices()
-        for device in devices:
-            climate_entity = ToshibaClimate(device)
-            new_entities.append(climate_entity)
-    except Exception as ex:
-        _LOGGER.error("Error during connection to Toshiba server %s", ex)
-        raise ConfigEntryNotReady("Error during connection to Toshiba server") from ex
+    devices = await device_manager.get_devices()
+    new_entities = [ToshibaClimate(device) for device in devices]
 
     if new_entities:
-        _LOGGER.info("Adding %d %s", len(new_entities), "climates")
+        _LOGGER.info("Adding %d climate entities", len(new_entities))
         async_add_devices(new_entities)
 
 

--- a/custom_components/toshiba_ac/config_flow.py
+++ b/custom_components/toshiba_ac/config_flow.py
@@ -65,8 +65,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
-
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:

--- a/custom_components/toshiba_ac/diagnostics.py
+++ b/custom_components/toshiba_ac/diagnostics.py
@@ -52,20 +52,46 @@ async def async_get_config_entry_diagnostics(
                 "ac_indoor_temperature": device.ac_indoor_temperature,
                 "ac_outdoor_temperature": device.ac_outdoor_temperature,
                 "ac_fan_mode": device.ac_fan_mode.name if device.ac_fan_mode else None,
-                "ac_swing_mode": device.ac_swing_mode.name if device.ac_swing_mode else None,
-                "ac_power_selection": device.ac_power_selection.name if device.ac_power_selection else None,
+                "ac_swing_mode": device.ac_swing_mode.name
+                if device.ac_swing_mode
+                else None,
+                "ac_power_selection": device.ac_power_selection.name
+                if device.ac_power_selection
+                else None,
                 "ac_merit_a": device.ac_merit_a.name if device.ac_merit_a else None,
                 "ac_merit_b": device.ac_merit_b.name if device.ac_merit_b else None,
-                "ac_air_pure_ion": device.ac_air_pure_ion.name if device.ac_air_pure_ion else None,
-                "ac_self_cleaning": device.ac_self_cleaning.name if device.ac_self_cleaning else None,
+                "ac_air_pure_ion": device.ac_air_pure_ion.name
+                if device.ac_air_pure_ion
+                else None,
+                "ac_self_cleaning": device.ac_self_cleaning.name
+                if device.ac_self_cleaning
+                else None,
                 "supported_features": {
-                    "ac_mode": [m.name for m in device.supported.ac_mode] if device.supported.ac_mode else [],
-                    "ac_fan_mode": [m.name for m in device.supported.ac_fan_mode] if device.supported.ac_fan_mode else [],
-                    "ac_swing_mode": [m.name for m in device.supported.ac_swing_mode] if device.supported.ac_swing_mode else [],
-                    "ac_power_selection": [m.name for m in device.supported.ac_power_selection] if device.supported.ac_power_selection else [],
-                    "ac_merit_a": [m.name for m in device.supported.ac_merit_a] if device.supported.ac_merit_a else [],
-                    "ac_merit_b": [m.name for m in device.supported.ac_merit_b] if device.supported.ac_merit_b else [],
-                    "ac_air_pure_ion": [m.name for m in device.supported.ac_air_pure_ion] if device.supported.ac_air_pure_ion else [],
+                    "ac_mode": [m.name for m in device.supported.ac_mode]
+                    if device.supported.ac_mode
+                    else [],
+                    "ac_fan_mode": [m.name for m in device.supported.ac_fan_mode]
+                    if device.supported.ac_fan_mode
+                    else [],
+                    "ac_swing_mode": [m.name for m in device.supported.ac_swing_mode]
+                    if device.supported.ac_swing_mode
+                    else [],
+                    "ac_power_selection": [
+                        m.name for m in device.supported.ac_power_selection
+                    ]
+                    if device.supported.ac_power_selection
+                    else [],
+                    "ac_merit_a": [m.name for m in device.supported.ac_merit_a]
+                    if device.supported.ac_merit_a
+                    else [],
+                    "ac_merit_b": [m.name for m in device.supported.ac_merit_b]
+                    if device.supported.ac_merit_b
+                    else [],
+                    "ac_air_pure_ion": [
+                        m.name for m in device.supported.ac_air_pure_ion
+                    ]
+                    if device.supported.ac_air_pure_ion
+                    else [],
                     "ac_energy_report": device.supported.ac_energy_report,
                 },
             }

--- a/custom_components/toshiba_ac/diagnostics.py
+++ b/custom_components/toshiba_ac/diagnostics.py
@@ -1,0 +1,79 @@
+"""Diagnostics support for Toshiba AC."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+TO_REDACT = {
+    "username",
+    "password",
+    "sas_token",
+    "device_id",
+    "ac_id",
+    "ac_unique_id",
+    "serial",
+    "mac",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    device_manager = hass.data[DOMAIN].get(entry.entry_id)
+
+    diagnostics_data: dict[str, Any] = {
+        "config_entry": async_redact_data(entry.as_dict(), TO_REDACT),
+    }
+
+    if device_manager is None:
+        diagnostics_data["error"] = "Device manager not found"
+        return diagnostics_data
+
+    try:
+        devices = await device_manager.get_devices()
+        devices_data = []
+        for device in devices:
+            device_info = {
+                "name": device.name,
+                "ac_id": "**REDACTED**",
+                "ac_unique_id": "**REDACTED**",
+                "device_id": "**REDACTED**",
+                "firmware_version": device.firmware_version,
+                "ac_status": device.ac_status.name if device.ac_status else None,
+                "ac_mode": device.ac_mode.name if device.ac_mode else None,
+                "ac_temperature": device.ac_temperature,
+                "ac_indoor_temperature": device.ac_indoor_temperature,
+                "ac_outdoor_temperature": device.ac_outdoor_temperature,
+                "ac_fan_mode": device.ac_fan_mode.name if device.ac_fan_mode else None,
+                "ac_swing_mode": device.ac_swing_mode.name if device.ac_swing_mode else None,
+                "ac_power_selection": device.ac_power_selection.name if device.ac_power_selection else None,
+                "ac_merit_a": device.ac_merit_a.name if device.ac_merit_a else None,
+                "ac_merit_b": device.ac_merit_b.name if device.ac_merit_b else None,
+                "ac_air_pure_ion": device.ac_air_pure_ion.name if device.ac_air_pure_ion else None,
+                "ac_self_cleaning": device.ac_self_cleaning.name if device.ac_self_cleaning else None,
+                "supported_features": {
+                    "ac_mode": [m.name for m in device.supported.ac_mode] if device.supported.ac_mode else [],
+                    "ac_fan_mode": [m.name for m in device.supported.ac_fan_mode] if device.supported.ac_fan_mode else [],
+                    "ac_swing_mode": [m.name for m in device.supported.ac_swing_mode] if device.supported.ac_swing_mode else [],
+                    "ac_power_selection": [m.name for m in device.supported.ac_power_selection] if device.supported.ac_power_selection else [],
+                    "ac_merit_a": [m.name for m in device.supported.ac_merit_a] if device.supported.ac_merit_a else [],
+                    "ac_merit_b": [m.name for m in device.supported.ac_merit_b] if device.supported.ac_merit_b else [],
+                    "ac_air_pure_ion": [m.name for m in device.supported.ac_air_pure_ion] if device.supported.ac_air_pure_ion else [],
+                    "ac_energy_report": device.supported.ac_energy_report,
+                },
+            }
+            devices_data.append(device_info)
+
+        diagnostics_data["devices"] = devices_data
+        diagnostics_data["device_count"] = len(devices)
+    except Exception as ex:
+        diagnostics_data["error"] = f"Failed to get devices: {ex}"
+
+    return diagnostics_data

--- a/custom_components/toshiba_ac/entity.py
+++ b/custom_components/toshiba_ac/entity.py
@@ -6,7 +6,8 @@ import logging
 
 from toshiba_ac.device import ToshibaAcDevice
 
-from homeassistant.helpers.entity import DeviceInfo, Entity
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN
 

--- a/custom_components/toshiba_ac/manifest.json
+++ b/custom_components/toshiba_ac/manifest.json
@@ -13,6 +13,6 @@
     "janus==1.0.0"
   ],
   "ssdp": [],
-  "version": "2025.3.1",
+  "version": "2026.1.0",
   "zeroconf": []
 }

--- a/custom_components/toshiba_ac/select.py
+++ b/custom_components/toshiba_ac/select.py
@@ -132,12 +132,8 @@ _SELECT_DESCRIPTIONS: Sequence[ToshibaAcSelectDescription] = [
 ]
 
 
-# This function is called as part of the __init__.async_setup_entry (via the
-# hass.config_entries.async_forward_entry_setup call)
 async def async_setup_entry(hass, config_entry, async_add_devices):
-    """Add sensor for passed config_entry in HA."""
-    # The hub is loaded from the associated hass.data entry that was created in the
-    # __init__.async_setup_entry function
+    """Add select entities for passed config_entry in HA."""
     device_manager = hass.data[DOMAIN][config_entry.entry_id]
     new_entities = []
 
@@ -147,14 +143,14 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
             if entity_description.is_supported(device.supported):
                 new_entities.append(ToshibaAcSelectEntity(device, entity_description))
             else:
-                _LOGGER.info(
+                _LOGGER.debug(
                     "AC device %s does not support %s",
                     device.name,
                     entity_description.key,
                 )
 
     if new_entities:
-        _LOGGER.info("Adding %d %s", len(new_entities), "selects")
+        _LOGGER.info("Adding %d select entities", len(new_entities))
         async_add_devices(new_entities)
 
 

--- a/custom_components/toshiba_ac/sensor.py
+++ b/custom_components/toshiba_ac/sensor.py
@@ -30,7 +30,9 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
         if device.supported.ac_energy_report:
             new_entities.append(ToshibaPowerSensor(device))
         else:
-            _LOGGER.debug("AC device %s does not support energy monitoring", device.name)
+            _LOGGER.debug(
+                "AC device %s does not support energy monitoring", device.name
+            )
 
         # Outdoor temperature sensor - value may be None when outdoor unit is off
         new_entities.append(ToshibaTempSensor(device))

--- a/custom_components/toshiba_ac/services.yaml
+++ b/custom_components/toshiba_ac/services.yaml
@@ -1,0 +1,3 @@
+reconnect:
+  name: Reconnect
+  description: Force reconnection to the Toshiba AC cloud service. Use this if your AC devices become unavailable due to connection issues.

--- a/custom_components/toshiba_ac/switch.py
+++ b/custom_components/toshiba_ac/switch.py
@@ -125,30 +125,26 @@ _SWITCH_DESCRIPTIONS: Sequence[ToshibaAcSwitchDescription] = [
 ]
 
 
-# This function is called as part of the __init__.async_setup_entry (via the
-# hass.config_entries.async_forward_entry_setup call)
 async def async_setup_entry(hass, config_entry, async_add_devices):
-    """Add all sensors for passed config_entry in HA."""
-    # The hub is loaded from the associated hass.data entry that was created in the
-    # __init__.async_setup_entry function
+    """Add switch entities for passed config_entry in HA."""
     device_manager = hass.data[DOMAIN][config_entry.entry_id]
-    new_entites = []
+    new_entities = []
 
     devices: list[ToshibaAcDevice] = await device_manager.get_devices()
     for device in devices:
         for entity_description in _SWITCH_DESCRIPTIONS:
             if entity_description.is_supported(device.supported):
-                new_entites.append(ToshibaAcSwitchEntity(device, entity_description))
+                new_entities.append(ToshibaAcSwitchEntity(device, entity_description))
             else:
-                _LOGGER.info(
+                _LOGGER.debug(
                     "AC device %s does not support %s",
                     device.name,
                     entity_description.key,
                 )
 
-    if new_entites:
-        _LOGGER.info("Adding %d %s", len(new_entites), "switches")
-        async_add_devices(new_entites)
+    if new_entities:
+        _LOGGER.info("Adding %d switch entities", len(new_entities))
+        async_add_devices(new_entities)
 
 
 class ToshibaAcSwitchEntity(ToshibaAcStateEntity, SwitchEntity):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
-homeassistant==2025.7.2
-# git+https://github.com/home-assistant/core.git@2025.7.2#egg=homeassistant
+homeassistant==2026.1.2
+# git+https://github.com/home-assistant/core.git@2026.1.2#egg=homeassistant
 # git+https://github.com/KaSroka/azure-iot-sdk-python@kasr/update_paho_mqtt#egg=azure-iot-device
 git+https://github.com/KaSroka/Toshiba-AC-control@main#egg=toshiba-ac
 pre-commit


### PR DESCRIPTION
 - Use ConfigEntryNotReady for connection failures (HA handles retry)
 - Use ConfigEntryAuthFailed for 401/403 errors (triggers reauth flow)
 - Add reconnect service for manual recovery without restart
 - Add diagnostics module with sensitive data redaction
 - Fix DeviceInfo import location (helpers.device_registry)
 - Remove deprecated CONNECTION_CLASS from config_flow
 - Update requirements_dev.txt to homeassistant==2026.1.2
 - Clean up logging levels (error→info/debug where appropriate)
 - Fix typo: new_entites→new_entities

Inspired by PR #261
Fixes #259
Fixes #216
Fixes #215

Related #70