### PR TITLE
Fix HA 2026.3+ compatibility and add auto-reconnect

### DIFF
--- a/custom_components/toshiba_ac/__init__.py
+++ b/custom_components/toshiba_ac/__init__.py
@@ -3,16 +3,19 @@
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 
 from toshiba_ac.device_manager import ToshibaAcDeviceManager
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers.event import async_track_time_interval
 
 from .const import DOMAIN
 
 PLATFORMS = ["climate", "select", "sensor", "switch"]
+RECONNECT_INTERVAL = timedelta(minutes=5)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,7 +64,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     device_manager.on_sas_token_updated_callback.add(sas_token_updated)
 
     # Store device manager
-    hass.data[DOMAIN][entry.entry_id] = device_manager
+    hass.data[DOMAIN][entry.entry_id] = {
+        "device_manager": device_manager,
+        "unsub_reconnect": None,
+    }
+
+    # Set up periodic connectivity check and auto-reconnect
+    async def _async_check_connectivity(_now=None) -> None:
+        """Check AMQP connectivity and reconnect if needed."""
+        devices = device_manager.devices
+        if not devices:
+            return
+
+        # Check if any device has lost its AMQP connection
+        any_unavailable = any(
+            not (d.amqp_api.sas_token and d.http_api.access_token)
+            for d in devices
+        )
+
+        if any_unavailable:
+            _LOGGER.warning(
+                "Toshiba AC connectivity lost, attempting reconnect"
+            )
+            try:
+                new_token = await device_manager.connect()
+                if new_token and new_token != entry.data.get("sas_token"):
+                    new_data = {**entry.data, "sas_token": new_token}
+                    hass.config_entries.async_update_entry(entry, data=new_data)
+                _LOGGER.info("Toshiba AC reconnected successfully")
+            except Exception as ex:
+                _LOGGER.debug("Toshiba AC reconnect failed: %s", ex)
+
+    unsub = async_track_time_interval(hass, _async_check_connectivity, RECONNECT_INTERVAL)
+    hass.data[DOMAIN][entry.entry_id]["unsub_reconnect"] = unsub
 
     # Register reconnect service (once per domain)
     await _async_register_services(hass)
@@ -94,7 +129,15 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
-        device_manager: ToshibaAcDeviceManager = hass.data[DOMAIN].pop(entry.entry_id)
+        entry_data = hass.data[DOMAIN].pop(entry.entry_id)
+        # Handle both old format (direct manager) and new format (dict)
+        if isinstance(entry_data, dict):
+            device_manager = entry_data["device_manager"]
+            unsub = entry_data.get("unsub_reconnect")
+            if unsub:
+                unsub()
+        else:
+            device_manager = entry_data
         try:
             await device_manager.shutdown()
         except Exception as ex:

--- a/custom_components/toshiba_ac/climate.py
+++ b/custom_components/toshiba_ac/climate.py
@@ -44,7 +44,8 @@ HVAC_MODE_TO_TOSHIBA = {v: k for k, v in TOSHIBA_TO_HVAC_MODE.items()}
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Add climate entities for passed config_entry in HA."""
-    device_manager = hass.data[DOMAIN][config_entry.entry_id]
+    entry_data = hass.data[DOMAIN][config_entry.entry_id]
+    device_manager = entry_data["device_manager"] if isinstance(entry_data, dict) else entry_data
 
     devices = await device_manager.get_devices()
     new_entities = [ToshibaClimate(device) for device in devices]

--- a/custom_components/toshiba_ac/diagnostics.py
+++ b/custom_components/toshiba_ac/diagnostics.py
@@ -26,7 +26,8 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    device_manager = hass.data[DOMAIN].get(entry.entry_id)
+    entry_data = hass.data[DOMAIN].get(entry.entry_id)
+    device_manager = entry_data["device_manager"] if isinstance(entry_data, dict) else entry_data
 
     diagnostics_data: dict[str, Any] = {
         "config_entry": async_redact_data(entry.as_dict(), TO_REDACT),

--- a/custom_components/toshiba_ac/entity.py
+++ b/custom_components/toshiba_ac/entity.py
@@ -56,5 +56,7 @@ class ToshibaAcStateEntity(ToshibaAcEntity):
 
     def _state_changed(self, _device: ToshibaAcDevice) -> None:
         """Call when the Toshiba AC device state changes."""
+        if not self.hass or not self.enabled:
+            return
         self.update_attrs()
         self.async_write_ha_state()

--- a/custom_components/toshiba_ac/manifest.json
+++ b/custom_components/toshiba_ac/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/h4de5/home-assistant-toshiba_ac/issues",
   "requirements": [
-    "toshiba-ac@git+https://github.com/KaSroka/Toshiba-AC-control@v0.3.11",
+    "toshiba-ac==0.3.11",
     "janus==1.0.0"
   ],
   "ssdp": [],

--- a/custom_components/toshiba_ac/select.py
+++ b/custom_components/toshiba_ac/select.py
@@ -134,7 +134,8 @@ _SELECT_DESCRIPTIONS: Sequence[ToshibaAcSelectDescription] = [
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Add select entities for passed config_entry in HA."""
-    device_manager = hass.data[DOMAIN][config_entry.entry_id]
+    entry_data = hass.data[DOMAIN][config_entry.entry_id]
+    device_manager = entry_data["device_manager"] if isinstance(entry_data, dict) else entry_data
     new_entities = []
 
     devices: list[ToshibaAcDevice] = await device_manager.get_devices()

--- a/custom_components/toshiba_ac/sensor.py
+++ b/custom_components/toshiba_ac/sensor.py
@@ -22,7 +22,8 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Add sensor entities for passed config_entry in HA."""
-    device_manager = hass.data[DOMAIN][config_entry.entry_id]
+    entry_data = hass.data[DOMAIN][config_entry.entry_id]
+    device_manager = entry_data["device_manager"] if isinstance(entry_data, dict) else entry_data
     new_entities = []
 
     devices: list[ToshibaAcDevice] = await device_manager.get_devices()

--- a/custom_components/toshiba_ac/switch.py
+++ b/custom_components/toshiba_ac/switch.py
@@ -127,7 +127,8 @@ _SWITCH_DESCRIPTIONS: Sequence[ToshibaAcSwitchDescription] = [
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Add switch entities for passed config_entry in HA."""
-    device_manager = hass.data[DOMAIN][config_entry.entry_id]
+    entry_data = hass.data[DOMAIN][config_entry.entry_id]
+    device_manager = entry_data["device_manager"] if isinstance(entry_data, dict) else entry_data
     new_entities = []
 
     devices: list[ToshibaAcDevice] = await device_manager.get_devices()


### PR DESCRIPTION
## Summary
- **Fix manifest.json**: use PyPI package (`toshiba-ac==0.3.11`) instead of `git+https://` which broke on HA 2026.3+ (fixes #277)
- **Add automatic AMQP reconnection** every 5 minutes when connectivity is lost, eliminating the need to manually restart HA or call `toshiba_ac.reconnect` (addresses #275)
- **Guard entity state callbacks** against unloaded entities to prevent crashes during integration unload

## Details

### Dependency fix (fixes #277)
The `toshiba-ac` library is published on PyPI as `toshiba-ac==0.3.11`. The `git+https://` format in `manifest.json` stopped working in HA 2026.3+. This simply switches to the PyPI package.

### Auto-reconnect (addresses #275)
When the AMQP connection to Toshiba cloud drops, entities become `unavailable` and the only recovery was restarting HA or calling the `toshiba_ac.reconnect` service manually. This adds a periodic check (every 5 minutes) that detects when devices have lost their AMQP/HTTP tokens and automatically attempts to reconnect.

### Callback safety
`_state_changed()` in `entity.py` now checks `self.hass` and `self.enabled` before calling `async_write_ha_state()`, preventing potential crashes if callbacks fire during entity unload.

## Test plan
- [x] Verified on HA 2026.3.4 (Home Assistant Green, aarch64)
- [x] Integration loads successfully with PyPI dependency
- [x] Climate entity connects and reports state correctly
- [x] All platform files (climate, select, sensor, switch, diagnostics) work with updated `hass.data` structure
- [x] Backwards compatible with old data format via `isinstance` check