### PR TITLE
Fix Power Consumption sensor stuck at 'unknown' after setup

### DIFF
--- a/custom_components/toshiba_ac/sensor.py
+++ b/custom_components/toshiba_ac/sensor.py
@@ -71,6 +71,14 @@ class ToshibaPowerSensor(ToshibaAcEntity, SensorEntity):
         # (rather than in the __init__)
         # self._device.register_callback(self.async_write_ha_state)
         self._device.on_energy_consumption_changed_callback.add(self.state_changed)
+        # Bootstrap: surface the cached value if energy data was already fetched
+        # before this entity finished registering. Without this, the very first
+        # poll's value is silently dropped (the callback only fires on subsequent
+        # changes), and the sensor stays "unknown" until the cumulative reading
+        # actually changes — which can take a long time on idle/low-load AC units.
+        if self._device.ac_energy_consumption is not None:
+            self._ac_energy_consumption = self._device.ac_energy_consumption
+            self.async_write_ha_state()
 
     async def async_will_remove_from_hass(self):
         """Entity being removed from hass."""


### PR DESCRIPTION
## Summary

The `ToshibaPowerSensor` relies on `on_energy_consumption_changed_callback` to receive values from the device manager. However the **very first** energy fetch can complete *before* `async_added_to_hass` runs (i.e. before the callback is registered), and subsequent fetches that return the **same** cumulative value won't fire the change callback either. As a result the sensor remains `unknown` until the AC actually consumes more energy and the cumulative reading changes — which can take a long time on idle or low-load units. On a freshly-installed integration this regularly leaves the sensor stuck for hours.

## Fix

Surface the cached `device.ac_energy_consumption` right after registering the callback in `async_added_to_hass`. 8 lines, no behavior change other than no longer dropping the bootstrap value.

```python
async def async_added_to_hass(self):
    self._device.on_energy_consumption_changed_callback.add(self.state_changed)
    # Bootstrap: surface the cached value if energy data was already fetched
    # before this entity finished registering.
    if self._device.ac_energy_consumption is not None:
        self._ac_energy_consumption = self._device.ac_energy_consumption
        self.async_write_ha_state()
```

## Reproduction (before fix)

1. Install integration, finish config flow.
2. Toshiba cloud returns initial cumulative Wh — visible in DEBUG log:
   `[toshiba_ac.device_manager] Power consumption for devices: {Bedroom: 800Wh, Work room: 565Wh, Living room: 1128Wh}`
3. `sensor.<device>_power_consumption` stays `unknown` indefinitely (until the cumulative value happens to differ on a later poll).

## Verification (after fix)

After applying the patch and a HA restart:
```
sensor.bedroom_power_consumption     = 803 Wh
sensor.workroom_power_consumption    = 604 Wh
sensor.living_room_power_consumption = 1132 Wh
```
Subsequent change-callbacks continue to work as before.

## Test plan

- [x] Verified locally on HA 2026.x with 3 Toshiba AC devices (built-in Wi-Fi).
- [x] No change to existing change-callback path; only adds a one-shot bootstrap on entity registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)