### PR TITLE
Handle unknown enum raw values gracefully (fix KeyError on setup and commands)

### DIFF
--- a/custom_components/toshiba_ac/__init__.py
+++ b/custom_components/toshiba_ac/__init__.py
@@ -4,6 +4,67 @@ from __future__ import annotations
 
 import logging
 
+
+def _toshiba_patch_from_raw() -> None:
+    """Make `from_raw` methods in toshiba_ac.device.fcu_state tolerant of unknown raw values.
+
+    The toshiba_ac library (KaSroka/Toshiba-AC-control) uses dict lookups in
+    `from_raw` static methods on nested classes of `ToshibaAcFcuState` (e.g.
+    `AcSwingMode`, `AcFanMode`). When a device reports a raw enum value the
+    library does not map (observed in the wild: `AcSwingMode` raw value 96),
+    the lookup raises `KeyError`, which:
+
+      - prevents the climate entity from being added during setup
+        (`Error adding entity climate.ac_toshiba ...`), and
+      - aborts every command path that internally reads the future state
+        (`send_state_to_ac` reads `ac_swing_mode` to validate support).
+
+    This patch wraps every nested `from_raw` so unknown values resolve to the
+    `NONE` value of the corresponding target enum. The `NONE` value is obtained
+    by calling the original `from_raw` with `ToshibaAcFcuState.NONE_VAL`, which
+    every mapping defines, so we do not need to import each target enum.
+    """
+    from toshiba_ac.device.fcu_state import ToshibaAcFcuState
+
+    none_val = ToshibaAcFcuState.NONE_VAL
+    patched: list[str] = []
+
+    for name in dir(ToshibaAcFcuState):
+        if name.startswith("_"):
+            continue
+        cls = getattr(ToshibaAcFcuState, name, None)
+        if not isinstance(cls, type) or not hasattr(cls, "from_raw"):
+            continue
+
+        original = cls.from_raw
+        try:
+            default = original(none_val)
+        except Exception:  # noqa: BLE001 — skip enums whose NONE_VAL mapping is missing
+            continue
+
+        def _make_safe(orig, default_val):
+            def safe_from_raw(raw):
+                try:
+                    return orig(raw)
+                except (KeyError, ValueError):
+                    return default_val
+            return safe_from_raw
+
+        cls.from_raw = staticmethod(_make_safe(original, default))
+        patched.append(name)
+
+    logging.getLogger(__name__).info(
+        "toshiba_ac safe-from_raw applied to: %s", ", ".join(patched) or "(none)"
+    )
+
+
+try:
+    _toshiba_patch_from_raw()
+except Exception:  # noqa: BLE001 — the patch must never break integration import
+    logging.getLogger(__name__).exception(
+        "Could not apply toshiba_ac safe from_raw patch"
+    )
+
 from toshiba_ac.device_manager import ToshibaAcDeviceManager
 
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/toshiba_ac/climate.py
+++ b/custom_components/toshiba_ac/climate.py
@@ -125,7 +125,10 @@ class ToshibaClimate(ToshibaAcStateEntity, ClimateEntity):
         if not self.is_on:
             return None
 
-        return pretty_enum_name(self._device.ac_power_selection)
+        try:
+            return pretty_enum_name(self._device.ac_power_selection)
+        except Exception:  # noqa: BLE001 — defensive against unknown enum raw values
+            return None
 
     @property
     def preset_modes(self) -> list[str] | None:
@@ -205,7 +208,10 @@ class ToshibaClimate(ToshibaAcStateEntity, ClimateEntity):
     @property
     def fan_mode(self) -> str | None:
         """Return the fan setting."""
-        return pretty_enum_name(self._device.ac_fan_mode)
+        try:
+            return pretty_enum_name(self._device.ac_fan_mode)
+        except Exception:  # noqa: BLE001 — defensive against unknown enum raw values
+            return None
 
     async def async_set_swing_mode(self, swing_mode: str) -> None:
         """Set new target swing operation."""
@@ -217,7 +223,10 @@ class ToshibaClimate(ToshibaAcStateEntity, ClimateEntity):
     @property
     def swing_mode(self) -> str | None:
         """Return the swing setting."""
-        return pretty_enum_name(self._device.ac_swing_mode)
+        try:
+            return pretty_enum_name(self._device.ac_swing_mode)
+        except Exception:  # noqa: BLE001 — defensive against unknown enum raw values
+            return None
 
     @property
     def current_temperature(self) -> float | None:


### PR DESCRIPTION
## Summary

Some Toshiba AC units report enum raw values that aren't mapped in the [KaSroka/Toshiba-AC-control](https://github.com/KaSroka/Toshiba-AC-control) library's `from_raw` static methods (observed in the wild: `AcSwingMode` raw value `96` from a Toshiba PepMartin running firmware 1.5.00). The unmapped dict lookup raises `KeyError`, which:

- **Aborts entity setup** with `Error adding entity climate.ac_toshiba for domain climate with platform toshiba_ac` — the config entry stays `loaded` but no `climate.*` entity ever registers.
- **Breaks every write path** because `send_state_to_ac` reads `future_state.ac_swing_mode` to validate support before sending — every `set_temperature` / `set_hvac_mode` / `set_fan_mode` returns HTTP 500.

This matches the symptoms reported in #226 *"No data from entities"*: the cloud connection is fine, debug logs show inbound state correctly, but no climate entity is produced.

## Stack trace (before fix)

```
ERROR (MainThread) [homeassistant.components.climate] Error adding entity
climate.ac_toshiba for domain climate with platform toshiba_ac
  File "/config/custom_components/toshiba_ac/climate.py", line 220, in swing_mode
  File "/usr/local/lib/python3.14/site-packages/toshiba_ac/device/__init__.py", line 291, in ac_swing_mode
  File "/usr/local/lib/python3.14/site-packages/toshiba_ac/device/fcu_state.py", line 419, in ac_swing_mode
    return ToshibaAcFcuState.AcSwingMode.from_raw(self._ac_swing_mode)
  File "/usr/local/lib/python3.14/site-packages/toshiba_ac/device/fcu_state.py", line 125, in from_raw
KeyError: 96
```

## Fix

1. **`__init__.py`** — monkey-patches every `from_raw` static method on classes nested inside `ToshibaAcFcuState` so unknown raw values fall back to the `NONE` value of the target enum. The default is obtained by calling the original `from_raw` with `ToshibaAcFcuState.NONE_VAL` (which every mapping defines), so we don't need to import each target enum class. The patch runs *before* `ToshibaAcDeviceManager` is imported so all callers see the safe version, and a top-level `try/except` ensures the patch can never break integration import.

2. **`climate.py`** — belt-and-suspenders `try/except` around the read-side `pretty_enum_name(self._device.ac_*)` getters (`preset_mode`, `fan_mode`, `swing_mode`) so entities stay functional even if the library patch is bypassed or new failure modes appear.

## Testing

Tested on Toshiba PepMartin (fw 1.5.00) with `AcSwingMode` raw value `96`:

| | Before | After |
|---|---|---|
| `climate.ac_toshiba` | never appears | loads as `off`, 22°C |
| `set_temperature` 24°C | HTTP 500 (`KeyError: 96`) | round-trips OK |
| `set_hvac_mode: cool` | HTTP 500 (`KeyError: 96`) | unit confirms via AMQP: `AcStatus: ON, AcMode: COOL, AcTemperature: 24` |
| Errors in log | one per setup + one per call | none |

Swing mode is reported as `None` after the fix (since raw `96` is still unknown), but the rest of the climate entity becomes fully functional. The mapping for raw `96` can be added separately once its meaning is identified upstream in [KaSroka/Toshiba-AC-control](https://github.com/KaSroka/Toshiba-AC-control).

## Notes

- The monkey-patch is intentionally defensive (silent fallback) rather than logging-on-every-call, to avoid log noise on devices that produce unknown values frequently.
- A `logging.getLogger(__name__).info(...)` line records which nested classes were patched at startup for diagnostics.